### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: trusty
+
+language: bash
+
+script:
+    - cd po
+    - make *.po
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 dist: trusty
-
 language: bash
-
 script:
-    - cd po
-    - make *.po
-    - make
+  - cd po
+  - make *.po
+  - make
+
+env:
+  global:
+    # encrypted github token used to deploy
+    - secure: >-
+        xlAWGNFLkDRbYN5MGpA7cVAesuwa0EdfiMZEfOGktwm8hSzqmKkaoF6fActJPv0lukU40pMaE6zTe6v8QPHNlV4MyQDKotSd3FU1Bth7g/oNlJ3SNwMT03dwASRIsBM1WwyiRHAZpvlogmxABN0kjB+2ZeD6aTIVW8tGZehBUQcsysJbQPpuyjwMOvtk0R6aOOuw7sPEF03ohmXsLWZsTTMAtFWrXqOvKxSxkBEEZdhe7Er3Nf+Ef77F5CUDdfPeqQ7itak2QrYuFyZoBqFsMi7vI3emh0nljtSKkpoYQCk7GNAyAoC9X8y2qCSQV33Wz+UXp83WpEyqll1H6/4BqNrDnm8ZCT64WXHv911nkn/0y/oRwxq+wumTkcU6a1AYYukf07/8z4ZfSNIT3m2g/wNAYq2VIs9Ay27aB23ZQUvcsdhSsGNvDjrAYRoLJUEzSqj8WnY8qr+ZpCWhWKZAe202JTquYEPwSkj1EFMFS/D6Rf8V3M4z0KZrnD6rceWnsAbZiWfp8APqbqTuZYMantaEMkix5C+6wGsSchXgjfSabvkicjVnFq4G3XEyrpDiMjrBo9gxePsKLpxzCNuA+4XjmhsB3IHSrqmnqqxn0eLkDZIrjeUfVocd1XbBlw0JCMDF3dqZsKhg/zSg8ID891p1XhpHbpweBi5PAu8SdtE=
+    - GIT_DEPLOY_REPO=https://$GITHUB_TOKEN@github.com/Jungle-Bus/transport_mapcss.git
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - cd .. && ./deploy.sh
+
+  on:
+    branch: ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
     - cd .. && ./deploy.sh
 
   on:
-    branch: ci
+    branch: master

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ev
+
+git config user.name "Travis CI"
+git config user.email "github@travis-ci.org"
+
+rm -rf .git
+git init
+
+git add .
+git commit --message "Deploy to GitHub Pages"
+git push --force "${GIT_DEPLOY_REPO}" master:gh-pages


### PR DESCRIPTION
Add continuous integration with travis

Close #21 

On each commit, it will update the translations files and create the zip.
(For now, it will not fail the build if you forgot to update the translation files or if the zip cannot be built. There is still some work to improve this part.)


On merge on master, it will deploy the whole directory to the `gh-page` branch.
If this is ok for you, we can remove the zip from the master branch and let travis take care of this.


