### PR TITLE
Walking bus for platform check

### DIFF
--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -230,7 +230,7 @@ node[railway=tram_stop][!public_transport]
 	assertMatch: "node railway=tram_stop";
 }
 
-node[public_transport=platform][!highway][!railway][!bus][!tram][!ferry]
+node[public_transport=platform][!highway][!railway][!bus][!tram][!ferry][!walking_bus]
 {
 	throwError: tr("Is this a bus or tram stop ? Add a tag to precise the kind of platform");
 	group: tr("Missing legacy tag on a public transport stop");


### PR DESCRIPTION
Add support of `walking_bus` in rule for platform check, in order to avoid this kind of errors in Osmose http://osmose.openstreetmap.fr/fr/error/79988609-212e-7da5-8d77-de9d083b990f