### PR TITLE
Allow disused:route

### DIFF
--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -59,12 +59,12 @@ meta[lang=zh_TW]
 	description: "未妥協驗證的運輸資料";
 }
 
-relation[type=route][!route]
+relation[type=route][!route][!disused:route]
 {
 	throwError: tr("Missing transportation mode, add a tag route = bus/coach/tram/etc");
 }
 
-relation[type=route_master][!route_master][!route]
+relation[type=route_master][!route_master][!route][!disused:route_master]
 {
 	throwError: tr("Missing transportation mode, add a tag route = bus/coach/tram/etc");
 }


### PR DESCRIPTION
`disused:route` on a route relation seems to be the most common way to indicate (temporary) disused routes. This PR would disable the warning for missing `route`/`route_master` if a `disused:route`/`disused:route_master` key is present. https://taginfo.openstreetmap.org/keys/disused%3Aroute#overview

Feel free to reject if you disagree :)