### PR TITLE
Lots of refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+transport.validator.zip
+po/i18n.pl
+po/*.po~

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,196 +1,158 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Petr Schönmann <pschonmann@gmail.com>, 2018
 # majkaz, 2019
 # trendspotter <jirka.p@volny.cz>, 2019
 # TK, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: TK, 2020\n"
-"Language-Team: Czech (https://www.transifex.com/openstreetmap-france/teams/17462/cs/)\n"
+"Language-Team: Czech (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/cs/)\n"
 "Language: cs\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Nekompromisní validace údajů o tranzitu"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "Chybějící způsob dopravy, přidej značku route = bus/coach/tram/apod."
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Chybějící způsob dopravy, změň značku route na route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr "Chybějící tag public_transport:version na relaci public_transport"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Chybějící tag network na relaci public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Chybějící tag operator na relaci public_transport"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Chybějící značka ref pro číslo linky u relace public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Chybějící tag from/to na relaci trasy public_transport"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Zastávky pravděpodobně nejsou ve správném pořadí"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Je toto autobusová zastávka nebo autobusová stanice ?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Specifikuj, zda se jedná o zastávku (platform) nebo místo zastavení "
 "(stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Je to autobusová zastávka ? Přidej tag highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Zkontroluj zda může být poznámka smazána"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "Značka network by měla být na dopravních linkách, nikoliv na zastávkách"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "Značka operator by měla být na dopravních linkách, nikoliv na zastávkách"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
 "Varianta cesty nepatří do žádné trasy, přidejte ji do route_master relation"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Zastávka není obsluhována žádnou linkou, přidejte ji do route relace "
 "příslušné dopravní linky"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Chybějící tag public_transport na zastávce hromadné dopravy"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Specifikuj, zda se jedná o zastávku (platform) nebo místo zastavení "
 "(stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Chybí starší tagování na zastávce veřejné dopravy"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "Tag network by měl být stejný pro route i route_master :  {0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr "Tag operator by měl být stejný pro route i route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr "Tag ref by měl být stejný pro route i route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "Tag colour by měl být stejný pro route i route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
 msgstr ""
-"Režim veřejné dopravy by měl být stejný pro route i route_master : {0} vs "
-"{1}"
+"Režim veřejné dopravy by měl být stejný pro route i route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Zkontrolujte tag colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Barevný kód by měl začínat znakem „#“ následovaným 3 nebo 6 číslicemi"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "Barva linky veřejné dopravy by měla být zanesena v barevné značce"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Autobusová zastávka má být uzlem"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "Interval je neplatný (zkuste několik minut)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "Délka je neplatná (zkuste několik minut)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Chybějící značka intervalu pro určení hlavního intervalu"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Chybějící tag opening_hours"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Chybějící jméno na zastávce veřejné dopravy"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Zkontrolujte tag operator: tento provozovatel neexistuje, možná se jedná o "
 "překlep."
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Zkontrolujte tag network: tato síť neexistuje, možná se jedná o překlep."
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -198,21 +160,17 @@ msgstr ""
 "Autobusová stanice je obvykle velká oblast, kde zastavuje mnoho autobusů, "
 "zkontrolujte, jestli lze tuto oblast nakreslit"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/de.po
+++ b/po/de.po
@@ -1,93 +1,77 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Christian Ostermann, 2019
 # ToniE <osm-ToniE@web.de>, 2020
 # Manfred Brandl <manfred@brandl.net>, 2021
 # kjon kjon <kjon@gmx.de>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: kjon kjon <kjon@gmx.de>, 2021\n"
-"Language-Team: German (https://www.transifex.com/openstreetmap-france/teams/17462/de/)\n"
+"Language-Team: German (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/de/)\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Kompromisslose Validieren von Daten des öffentlichen Verkehrs"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "Fehlendes Verkehrsmittel, ergänze den Tag route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Fehlendes Verkehrsmittel, ändere Tag route in route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Fehlender public_transport:version Tag an einer public_transport Routen-"
 "Relation"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Fehlender network Tag bei einer public_transport Relation"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Fehlender operator Tag bei einer public_transport Relation"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
-msgstr ""
-"Fehlender ref Tag für Liniennummer bei einer public_transport Relation"
+msgstr "Fehlender ref Tag für Liniennummer bei einer public_transport Relation"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Fehlender from/to Tag bei einer public_transport Routen-Relation"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr ""
 "Die Haltestellen sind möglicherweise nicht in der richtigen Reihenfolge"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Ist das eine Bushaltestelle oder ein Busbahnhof?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
-"Gebe bitte an, ob das eine Haltestelle (platform) oder eine Position auf der"
-" Fahrbahn ist (stop_position)"
+"Gebe bitte an, ob das eine Haltestelle (platform) oder eine Position auf der "
+"Fahrbahn ist (stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Ist das eine Bushaltestelle? Wenn ja, Tag highway=bus_stop hinzufügen"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Prüfe ob die Notiz gelöscht werden kann"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "Der Verkehrsverbund soll in den Linien und nicht an den Haltestellen "
 "enthalten sein"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "Das Verkehrsunternehmen soll in den Linien und nicht an den Haltestellen "
 "enthalten sein"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -95,57 +79,46 @@ msgstr ""
 "Die Linienvariante gehört zu keiner Linie, füge sie zur route_master "
 "Relation hinzu"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Diese Haltestelle wird von keiner Linie bedient, füge sie zu einer Routen-"
 "Relation hinzu"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Fehlender public_transport Tag an einer Haltestelle"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
-"Gebe bitte an, ob das eine Haltestelle (platform) oder eine Position auf den"
-" Schienen ist (stop_position)"
+"Gebe bitte an, ob das eine Haltestelle (platform) oder eine Position auf den "
+"Schienen ist (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Eine notwendige Eigenschaft für die Haltestelle fehlt"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 "Der network-Tag sollte bei route und route_master gleich sein: {0} vs. {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Der operator-Tag sollte bei route und route_master gleich sein: {0} vs. {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
-msgstr ""
-"Der ref-Tag sollte bei route und route_master gleich sein: {0} vs. {1}"
+msgstr "Der ref-Tag sollte bei route und route_master gleich sein: {0} vs. {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 "Der colour-Tag sollte bei route und route_master gleich sein: {0} vs. {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -153,58 +126,45 @@ msgstr ""
 "Das Verkehrsmittel sollte für die route und den route_master gleich sein: "
 "{0} versus {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "colour Tag überprüfen"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Der Farbcode sollte mit '#' starten, gefolgt von 3 oder 6 Ziffern."
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "Die Farbe der Linie des öffentlichen Verkehrs soll in der Eigenschaft "
 "\"Colour\" enthalten sein"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Eine Bushaltestelle soll ein Knoten sein"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "Das Intervall ist ungültig (Nimm die Anzahl der Minuten)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "Die Dauer ist ungültig (Nimm die Anzahl der Minuten)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Eigenschaft interval zur Angabe des Hauptintervalls fehlt"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Fehlende Eigenschaft \"opening_hours\""
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Haltestelle ohne Namen"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Prüfe die Eigenschaft operator: dieser existiert nicht, vielleicht ein "
 "Tippfehler"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Prüfe die Eigenschaft network: dieses existiert nicht, vielleicht ein "
 "Tippfehler"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -212,17 +172,14 @@ msgstr ""
 "Ein Busbahnhof ist normalerweise eine größere Fläche an der viele Busse "
 "halten, vielleicht kannst du die Fläche zeichnen"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "Ist dies eine Bus- oder Tramhaltestelle? Ergänze ein Tag, um die Art des "
 "Bahnsteigs zu präzisieren"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "U-Bahneingänge sollen als Punkte gemappt werden"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
@@ -230,7 +187,6 @@ msgstr ""
 "Der Bahnhofseingag soll Teil eines Gebäudes oder eines Weges (Stufen, "
 "Fußweg, etc.) sein"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/es.po
+++ b/po/es.po
@@ -1,90 +1,74 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Franco, 2018
 # Jorge Sanz <sanchi2@gmail.com>, 2020
 # Hugoren Martinako <aumpfbahn@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Hugoren Martinako <aumpfbahn@gmail.com>, 2021\n"
-"Language-Team: Spanish (https://www.transifex.com/openstreetmap-france/teams/17462/es/)\n"
+"Language-Team: Spanish (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/es/)\n"
 "Language: es\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Validación inflexible de los datos de tránsito"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
 "Falta el modo de transporte, añada una etiqueta route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr ""
 "Falta el modo de transporte, reemplazar la etiqueta route por route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Falta etiqueta public_transport:version en una relación de ruta "
 "public_transport"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Falta etiqueta network en una relación public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Falta etiqueta operator en una relación public_transport"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr ""
 "Falta etiqueta ref con el número de línea, en una relación public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Falta etiqueta from/to en una relación de ruta public_transport"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Las paradas pueden no estar en el orden correcto"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "¿Es una parada de autobús o una estación de autobús?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Especificar si es una parada (platform) o una ubicación en la carretera "
 "(stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "¿Es una parada de autobús? añada la etiqueta highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Comprobar si la nota puede borrarse"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "La red debe estar en las líneas de transporte y no en las paradas"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
-msgstr ""
-"El operador debe estar en las líneas de transporte y no en las paradas"
+msgstr "El operador debe estar en las líneas de transporte y no en las paradas"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -92,29 +76,23 @@ msgstr ""
 "El recorrido no pertenece a ninguna línea, añadirlo a la relación "
 "route_master"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "La parada no está relacionada a ninguna línea, añadirla a una relación de "
 "ruta"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Falta etiqueta public_transport en una parada de transporte público"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Especificar si es una parada (platform) o una ubicación sobre los rieles "
 "(stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Falta etiqueta heredada en una parada de transporte público"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -122,89 +100,72 @@ msgstr ""
 "La etiqueta de network debe ser la misma para la route y la route_master: "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "La etiqueta de operator debe ser la misma para la route y la route_master: "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr ""
-"La etiqueta de ref debe ser la misma para la route y la route_master: {0} vs"
-" {1}"
+"La etiqueta de ref debe ser la misma para la route y la route_master: {0} vs "
+"{1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"La etiqueta colour debe ser la misma para la route y la route_master: {0} vs"
-" {1}"
+"La etiqueta colour debe ser la misma para la route y la route_master: {0} vs "
+"{1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
 msgstr ""
-"El modo de transporte debe ser el mismo para la route y la route_master: {0}"
-" vs {1}"
+"El modo de transporte debe ser el mismo para la route y la route_master: {0} "
+"vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Comprobar la etiqueta colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "El código de color debe comenzar con '#' seguido de 3 o 6 dígitos"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "El color de la línea de transporte público debe estar en la etiqueta colour."
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Una parada de autobús se supone que es un nodo"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "El intervalo no es válido (intente un número de minutos)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "La duración no es válida (intente un número de minutos)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Falta etiqueta interval para especificar el intervalo principal"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Falta etiqueta opening_hours"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Nombre perdido en una parada de transporte público"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Verifique la etiqueta del operador: este operador no existe, puede ser un "
 "error tipográfico"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Verifique la etiqueta de la red: esta red no existe, puede ser un error "
 "tipográfico"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -212,17 +173,14 @@ msgstr ""
 "Una estación de autobuses es generalmente un área grande donde se detienen "
 "muchos autobuses, verifique si puede dibujar esta área"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "¿Es una parada de autobús o tranvía? Agregue una etiqueta para precisar el "
 "tipo de plataforma"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Las entradas al metro deberían ser mapeadas como nodos"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
@@ -230,7 +188,6 @@ msgstr ""
 "La entrada de la estación debería ser parte de un edificio o de un vial "
 "(escaleras, aceras, etc...)"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1,208 +1,164 @@
-# 
+#
 # Translators:
 # imni <iriman@chmail.ir>, 2018
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: imni <iriman@chmail.ir>, 2018\n"
-"Language-Team: Persian (https://www.transifex.com/openstreetmap-france/teams/17462/fa/)\n"
+"Language-Team: Persian (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/fa/)\n"
 "Language: fa\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr ""
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
-"شیوهٔ حمل‌ونقل عمومی مشخص نشده. یکی از تگ‌های route = bus/coach/tram/...‎ را"
-" وارد کنید."
+"شیوهٔ حمل‌ونقل عمومی مشخص نشده. یکی از تگ‌های route = bus/coach/tram/...‎ را "
+"وارد کنید."
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
-msgstr ""
-"شیوهٔ حمل‌ونقل عمومی مشخص نشده. تگ route را به route_master تغییر دهید"
+msgstr "شیوهٔ حمل‌ونقل عمومی مشخص نشده. تگ route را به route_master تغییر دهید"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "کمبود تگ public_transport:version روی رابطهٔ route از نوع public_transport"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "کمبود تگ network روی رابطهٔ public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "کمبود تگ operator روی رابطهٔ public_transport"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "کمبود تگ ref برای شمارهٔ خط، روی رابطهٔ public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "تگ from/to در رابطهٔ public_transport وجود ندارد"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "ایستگاه‌ها به ترتیب نیستند"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "ایستگاه اتوبوس است (stop) یا پایانهٔ اتوبوس (station)؟"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
-"مشخص کنید آیا ایستگاه است (سکو، platform) یا نقطه‌ای در جاده (stop_position،"
-" محل توقف وسیله)"
+"مشخص کنید آیا ایستگاه است (سکو، platform) یا نقطه‌ای در جاده (stop_position، "
+"محل توقف وسیله)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "ایستگاه اتوبوس است؟ تگ highway=bus_stop را بدهید"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "بررسی کنید آیا یادداشت را می‌توان حذف کرد"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "network باید روی خطوط حمل‌ونقل باشد نه روی ایستگاه‌ها"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "operator باید روی خطوط حمل‌ونقل باشد نه روی ایستگاه‌ها"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
 "خط جایگزین به هیچ خطی تعلق ندارد. آن را به رابطهٔ route_master اضافه کنید."
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
-msgstr ""
-"هیچ خطی از ایستگاه نمی‌گذرد. ایستگاه را به یک رابطهٔ route اضافه کنید."
+msgstr "هیچ خطی از ایستگاه نمی‌گذرد. ایستگاه را به یک رابطهٔ route اضافه کنید."
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "کمبود تگ public_transport روی ایستگاه حمل‌ونقل عمومی"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "مشخص کنید آیا ایستگاه (platform، سکو) است یا مکانی در کنار ریل "
 "(stop_position، محل توقف وسیله)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "کمبود تگ قدیم برای یک ایستگاه حمل‌ونقل عمومی"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr ""
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
 msgstr ""
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr ""
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr ""
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr ""
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr ""
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr ""
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr ""
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr ""
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr ""
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
 msgstr ""
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,123 +1,100 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Philippe Verdy, 2019
 # deuzeffe, 2019
 # Noémie <nlehuby@zaclys.net>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Noémie <nlehuby@zaclys.net>, 2021\n"
-"Language-Team: French (https://www.transifex.com/openstreetmap-france/teams/17462/fr/)\n"
+"Language-Team: French (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/fr/)\n"
 "Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Une validation rigoureuse des données de transport en commun"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
 "Le mode est manquant, ajouter un attribut “route”=“bus/coach/tram/etc.”"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
-msgstr ""
-"Le mode est manquant, transformer l’attribut “route” en “route_master”"
+msgstr "Le mode est manquant, transformer l’attribut “route” en “route_master”"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
-"La version de schéma est manquante, ajouter un attribut "
-"“public_transport:version”"
+"La version de schéma est manquante, ajouter un attribut “public_transport:"
+"version”"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Le réseau est manquant, ajouter un attribut “network”"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "L’opérateur est manquant, ajouter un attribut “operator”"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Le numéro de ligne est manquant, ajouter un attribut “ref”"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr ""
 "L’origine ou la destination est manquante, renseigner les attributs “from” "
 "et “to”"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Les arrêts ne sont peut-être pas dans le bon ordre"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Est-ce un arrêt de bus ou une gare routière ?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Préciser s’il s’agit d’une station (“platform”) ou d’un emplacement sur la "
 "route (“stop_position”)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Est-ce un arrêt de bus ? Ajouter l’attribut “highway”=“bus_stop”"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Vérifier si la note peut être supprimée"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "Le réseau devrait être porté par les lignes de transport et non par les "
 "arrêts"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "L’opérateur devrait être porté par les lignes de transport et non par les "
 "arrêts"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
-"Le trajet n’appartient à aucune ligne, l’ajouter à la relation "
-"“route_master”"
+"Le trajet n’appartient à aucune ligne, l’ajouter à la relation “route_master”"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "L’arrêt n’est desservi par aucune ligne, l’ajouter à une relation “route”"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Il manque l’attribut “public_transport” sur un arrêt"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
-"Préciser s’il s’agit d’un quai (“platform”) ou d’une position d’arrêt sur la"
-" voie (“stop_position”)"
+"Préciser s’il s’agit d’un quai (“platform”) ou d’une position d’arrêt sur la "
+"voie (“stop_position”)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Ancien attribut manquant sur un arrêt de transport en commun"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -125,15 +102,13 @@ msgstr ""
 "Le nom du réseau doit être le même pour le trajet et pour la ligne : {0} vs "
 "{1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Le nom de l'opérateur doit être le même pour le trajet et pour la ligne : "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
@@ -141,73 +116,58 @@ msgstr ""
 "Le numéro de ligne doit être le même pour le trajet et pour la ligne : {0} "
 "vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 "La couleur doit être la même pour le trajet et pour la ligne : {0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
 msgstr ""
-"Le mode de transport doit être le même pour le trajet et pour la ligne : {0}"
-" vs {1}"
+"Le mode de transport doit être le même pour le trajet et pour la ligne : {0} "
+"vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Attribut de couleur à vérifier"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Le code couleur doit commencer par \"#\" et suivi par 3 ou 6 chiffres"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "La couleur de la ligne doit être dans un attribut 'colour'"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Un arrêt de bus est censé être un nœud "
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "La fréquence de passage est invalide (essayer un nombre en minutes)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "La durée est invalide (essayer un nombre en minutes)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr ""
 "Il manque l'attribut interval pour préciser la fréquence de passage "
 "principale"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Attribut opening_hours (heures de service) manquant"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Nom manquant sur un arrêt de transport"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Vérifier l'opérateur renseigné dans l'attribut \"operator\" : ce "
 "transporteur n'existe pas, c'est peut-être une faute d'orthographe"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Vérifier le réseau renseigné dans l'attribut \"network\" : ce réseau "
 "n'existe pas, c'est peut-être une faute d'orthographe"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -215,25 +175,21 @@ msgstr ""
 "Une gare routière est normalement une large zone où s'arrêtent de nombreux "
 "bus. Vérifier si un polygone peut être dessiné pour la représenter"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "Est-ce un arrêt de bus ou de tramway ? Ajouter un attribut pour préciser le "
 "type d'arrêt."
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Les bouches de métro doivent être cartographiées sur des nœuds"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
-"La bouche de métro doit faire partie d'un bâtiment ou d'un élément de voirie"
-" (escalier, chemin piéton, etc)"
+"La bouche de métro doit faire partie d'un bâtiment ou d'un élément de voirie "
+"(escalier, chemin piéton, etc)"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1,118 +1,96 @@
-# 
+#
 # Translators:
 # Navhy, 2019
 # Iváns, 2019
 # ccpr1l <csdpe0810-tf@yahoo.es>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: ccpr1l <csdpe0810-tf@yahoo.es>, 2020\n"
-"Language-Team: Galician (https://www.transifex.com/openstreetmap-france/teams/17462/gl/)\n"
+"Language-Team: Galician (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/gl/)\n"
 "Language: gl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Validación non flexíbel dos datos de tránsito"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
 "Falla o xeito de transporte, engade unha etiqueta route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr ""
 "Falla o xeito de transporte, subtituír a etiqueta 'route' por 'route_master'"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Falla a etiqueta 'public_transport:version' nunha relación de rota "
 "'public_transport'"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Falla a etiqueta 'network' nunha relación 'public_transport'"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Falla a etiqueta 'operator' nunha relación 'public_transport'"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr ""
 "Falla a etiqueta 'ref' co número de liña, nunha relación 'public_transport'"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Falla a etiqueta 'from/to' nunha relación de rota 'public_transport'"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "As paraxes poden non estar na orde correcta"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "É unha paraxe de bus ou unha estación de autobuses?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Especificar se é unha paraxe nunha plataforma ('platform') ou nunha "
 "localización na estrada ('stop_position')"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "É unha paraxe de bus? Engade a etiqueta 'highway=bus_stop'"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Comprobar se a nota pode eliminarse"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "A rede ten que estar nas liñas de transporte e non nas paraxes"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "O operador ten que estar nas liñas de transporte e non nas paraxes"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
 "O percorrido non pertence a ningunha liña, engádeo á relación 'route_master'"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "A paraxe non está relacionada a ningunha liña, engádea a unha relación de "
 "rota"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
-msgstr ""
-"Falla a etiqueta 'public_transport' nunha paraxe de transporte público"
+msgstr "Falla a etiqueta 'public_transport' nunha paraxe de transporte público"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Especificar se é unha paraxe nunha plataforma ('platform') ou nunha "
 "localización sobre os raís ('stop_position')"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Falla a etiqueta herdada nunha paraxe de transporte público"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -120,15 +98,13 @@ msgstr ""
 "A etiqueta de 'network' ten que ser a mesma para a 'route' e a "
 "'route_master': {0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "A etiqueta de 'operator' ten que ser a mesma para a 'route' e a "
 "'route_master': {0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
@@ -136,7 +112,6 @@ msgstr ""
 "A etiqueta de 'ref' ten que ser a mesma para a 'route' e a 'route_master': "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -144,7 +119,6 @@ msgstr ""
 "A etiqueta 'colour' ten que ser a mesma para a 'route' e a 'route_master': "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -152,58 +126,45 @@ msgstr ""
 "O modo de transporte ten que ser o mesmo para a 'route' e a 'route_master': "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Comprobar a etiqueta 'colour'"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr ""
 "O código de cor ten que comezar cun cancelo '#' seguido duns 3 ou 6 díxitos"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "A cor da liña de transporte público ten que estar na etiqueta 'colour'."
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Unha paraxe de bus suponse que é un nó"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "O intre non é válido (tente un número de minutos)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "A dura non é válida (tente un número de minutos)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Falla a etiqueta 'interval' para especificar o intre principal"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Falla a etiqueta 'opening_hours'"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Falla o nome nunha paraxe de transporte público"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
-"Verificar a etiqueta do operador: este operador non existe, pode ser un erro"
-" tipográfico (gralla)"
+"Verificar a etiqueta do operador: este operador non existe, pode ser un erro "
+"tipográfico (gralla)"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Verificar a etiqueta de rede: esta rede non existe, pode ser un erro "
 "tipográfico (gralla)"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -211,23 +172,19 @@ msgstr ""
 "Unha estación de autobuses adoita ser unha área grande onde se deteñen "
 "moitos buses, verifica se podes debuxar esta área"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "Isto é unha parada de autobús ou de tranvía? Engade unha etiqueta que "
 "especifique o tipo de plataforma"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,93 +1,78 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Gábor Babos <gabor.babos@gmail.com>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Gábor Babos <gabor.babos@gmail.com>, 2020\n"
-"Language-Team: Hungarian (https://www.transifex.com/openstreetmap-france/teams/17462/hu/)\n"
+"Language-Team: Hungarian (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/hu/)\n"
 "Language: hu\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Tömegközlekedési adatok teljes körű érvényesítése"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
 "Hiányzik a közlekedési mód. Adjon hozzá egy [route=bus/coach/tram/stb.] "
 "címkét"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr ""
 "Hiányzik a közlekedési mód. Módosítsa a [route] címkét erre: [route_master]"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Hiányzik a [public_transport:version] címke a [public_transport] "
 "útvonalkapcsolatról"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Hiányzik a [network]hálózatcímke a [public_transport] kapcsolatról"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr ""
 "Hiányzik az [operator] üzemeltető címke a [public_transport] kapcsolatról"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr ""
 "Hiányzik a vonal számát jelölő [ref] címke a [public_transport] kapcsolatról"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Hiányzik a [from/to] címke a [public_transport] [route] kapcsolatról"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Lehet, hogy a megállók helytelen sorrendben vannak"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Ez buszmegálló vagy buszállomás?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Határozza meg, hogy ez egy megálló/peron [platform] vagy a jármű "
 "megállásának helye az úton [stop_position]"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Ez egy buszmegálló? Adja hozzá a [highway=bus_stop] címkét"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Ellenőrizze, hogy törölhető-e a megjegyzés"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "A hálózat [network] megjelölésének a tömegközlekedési útvonalakon kell "
 "lennie, nem pedig a megállókon"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "Az üzemeltető [operator] megjelölésének a tömegközlekedési útvonalakon kell "
 "lennie, nem pedig a megállókon"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -95,45 +80,37 @@ msgstr ""
 "Ez a vonalváltozat egyetlen útvonalhoz sem tartozik. Adja hozzá a "
 "[route_master] kapcsolathoz"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Ez a megálló egyetlen vonalhoz sem tartozik. Adja hozzá egy [route] "
 "kapcsolathoz"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Hiányzik a [public_transport] címke a tömegközlekedési megállóról"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Határozza meg, hogy ez egy megálló/peron [platform] vagy a jármű "
 "megállásának helye a sínen [stop_position]"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Hiányzik az örökségcímke a tömegközlekedési megállóról"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"A [network] hálózat címkének meg kell egyeznie a [route] és a [route_master]"
-" esetében: {0} vs {1}"
+"A [network] hálózat címkének meg kell egyeznie a [route] és a [route_master] "
+"esetében: {0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Az [operator] üzemeltető címkének meg kell egyeznie a [route] és a "
 "[route_master] esetében: {0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
@@ -141,7 +118,6 @@ msgstr ""
 "A [ref] címkének meg kell egyeznie a [route] és a [route_master] esetében: "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -149,7 +125,6 @@ msgstr ""
 "A [colour] szín címkének meg kell egyeznie a [route] és a [route_master] "
 "esetében: {0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -157,61 +132,47 @@ msgstr ""
 "A tömegközlekedési mód címkéjének meg kell egyeznie a [route] és a "
 "[route_master] esetében: {0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Ellenőrizze a [colour] szín címkét"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr ""
 "A [colour] szín címkének # jellel kell kezdődnie, amelyet 3 vagy 6 számjegy "
 "követhet"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "A tömegközlekedési vonal színének a [colour] szín címkében kell szerepelnie"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "A buszmegálló feltételezhetően egy pont"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr ""
-"Érvénytelen [interval] követési időköz (próbálja meg a percek számát "
-"megadni)"
+"Érvénytelen [interval] követési időköz (próbálja meg a percek számát megadni)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "Érvénytelen időtartam (próbálja meg a percek számát megadni)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Hiányzik az [interval] címke a fő követési időköz meghatározásához"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Hiányzik az [opening_hours] nyitva tartás címke"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Hiányzik a [name] név a tömegközlekedési megállóról"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
-"Ellenőrizze az [operator] címkét: ilyen üzemeltető nem létezik, talán elírás"
-" történt"
+"Ellenőrizze az [operator] címkét: ilyen üzemeltető nem létezik, talán elírás "
+"történt"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Ellenőrizze a [network] címkét: ilyen hálózat nem létezik, talán elírás "
 "történt"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -219,23 +180,19 @@ msgstr ""
 "A buszállomás általában egy nagyobb terület, ahol sok busz megáll. "
 "Ellenőrizze, hogy meg tudja-e rajzolni ezt a területet"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "Ez busz- vagy villamosmegálló? A peron típusának pontosításához adjon hozzá "
 "egy címkét."
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/it.po
+++ b/po/it.po
@@ -1,93 +1,78 @@
-# 
+#
 # Translators:
 # Lorenzo Beltrami <lorenzo.beba@gmail.com>, 2020
 # Marco <marcxosm@gmail.com>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Marco <marcxosm@gmail.com>, 2020\n"
-"Language-Team: Italian (https://www.transifex.com/openstreetmap-france/teams/17462/it/)\n"
+"Language-Team: Italian (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/it/)\n"
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Validazione senza compromessi sui dati di transito"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
-"Manca la modalità di trasporto, aggiungere l’etichetta route = "
-"bus/coach/tram/ecc."
+"Manca la modalità di trasporto, aggiungere l’etichetta route = bus/coach/"
+"tram/ecc."
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr ""
 "Manca la modalità di trasporto, cambiare l’etichetta da route a route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
-"Manca l’etichetta public_transport:version su una relazione di linea di tipo"
-" public_transport"
+"Manca l’etichetta public_transport:version su una relazione di linea di tipo "
+"public_transport"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Manca l’etichetta network su una relazione di tipo public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Manca l’etichetta operator su una relazione di tipo public_transport"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr ""
 "Manca l’etichetta ref per il numero di linea di una relazione di tipo "
 "public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Manca l‘etichetta from/to su una relazione di tipo public_transport"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Le fermate potrebbero non essere in ordine"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Si tratta di una stazione o di una fermata dei bus?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
-"Specificare se si tratta di una  fermata (platform) o di un punto di arresto"
-" sulla strada (stop_position)"
+"Specificare se si tratta di una  fermata (platform) o di un punto di arresto "
+"sulla strada (stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "È una fermata dei bus? Aggiungere highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Verificare se la nota può essere eliminata"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "L’etichetta network dovrebbe stare sulle linee di trasporto e non sulle "
 "fermate"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "L’etichetta operator dovrebbe stare sulle linee di trasporto e non sulle "
 "fermate"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -95,30 +80,23 @@ msgstr ""
 "La variante al percorso non appartiene ad alcuna linea, aggiungerla alla "
 "relazione route_master"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "La fermata non  è servita da alcuna linea, aggiungerla ad una relazione di "
 "tipo ‘route’"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
-msgstr ""
-"Manca l’etichetta public_transport sulla fermata di trasporto pubblico"
+msgstr "Manca l’etichetta public_transport sulla fermata di trasporto pubblico"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Specificare se si tratta di una fermata (platform) oppure di un punto di "
 "arresto sui binari (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Manca la vecchia etichetta sulla fermata di trasporto pubblico"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -126,15 +104,13 @@ msgstr ""
 "L’etichetta network dovrebbe avere lo stesso valore per route e "
 "route_master: {0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "L’etichetta operator dovrebbe avere lo stesso valore per route e "
 "route_master: {0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
@@ -142,15 +118,13 @@ msgstr ""
 "L’etichetta ref dovrebbe avere lo stesso valore per route e route_master: "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"L’etichetta colour dovrebbe avere lo stesso valore per route e route_master:"
-" {0} vs {1}"
+"L’etichetta colour dovrebbe avere lo stesso valore per route e route_master: "
+"{0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -158,58 +132,45 @@ msgstr ""
 "La modalità di trasporto pubblico dovrebbe essere la stessa per route e "
 "route_master: {0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Verifica l’etichetta colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Il codice del colore dovrebbe iniziare con ‘#’ seguito da 3 o 6 cifre"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "Il colore della linea di trasporto pubblico dovrebbe stare nell’etichetta "
 "colour"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Una fermata dell’autobus dovrebbe essere u nodo"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "L’intervallo non è valido (prova con dei valori in minuti)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "La durata non è valida (prova con dei valori in minuti)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Manca l’etichetta interval che specifica l’intervallo principale"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Etichetta opening_hours mancante"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Manca il nome su una fermata del trasporto pubblico"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Verifica l’etichetta operator: questo operatore non esiste, potrebbe "
 "trattarsi di un refuso"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Verifica l’etichetta network: questa rete non esiste, potrebbe trattarsi di "
 "un refuso"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -217,23 +178,19 @@ msgstr ""
 "Una stazione dei bus solitamente è una vasta area dove sostano gli autobus, "
 "verifica se puoi disegnare quest’area"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
-"È una fermata dell’autobus o del tram? Aggiungi un’etichetta per specificare"
-" il tipo di piattaforma"
+"È una fermata dell’autobus o del tram? Aggiungi un’etichetta per specificare "
+"il tipo di piattaforma"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,199 +1,167 @@
-# 
+#
 # Translators:
 # Tom Konda <tom.konda.dev@gmail.com>, 2020
 # Shu Higashi <higa432@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Shu Higashi <higa432@gmail.com>, 2021\n"
-"Language-Team: Japanese (https://www.transifex.com/openstreetmap-france/teams/17462/ja/)\n"
+"Language-Team: Japanese (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/ja/)\n"
 "Language: ja\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "乗り換えデータの妥協のないバリデーション"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
-msgstr "transportation modeがありません、route = bus/coach/tram/etcタグをいずれか追加します"
+msgstr ""
+"transportation modeがありません、route = bus/coach/tram/etcタグをいずれか追加"
+"します"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "transportation modeがありません、routeタグをroute_masterに変更します"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
-msgstr " public_transportルートリレーションにpublic_transport:versionタグがない "
+msgstr ""
+" public_transportルートリレーションにpublic_transport:versionタグがない "
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "public_transportリレーションにnetworkタグがない "
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "public_transportリレーションにoperatorタグがない"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "public_transportリレーションに路線番号を示すrefタグがない "
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "public_transportリレーションにfromとtoのタグがない "
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "stopの順番が誤っている可能性があります"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "バス停またはバスターミナルのいずれかです。"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr "停止場所 (platform)または道路上の停止位置(stop_position)を指定します"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "これがバス停ならば、highway=bus_stopのタグを追加してください"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "メモを削除できるかチェックします"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "ネットワークはstopではなく輸送ライン上にあるべきです"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "operatorはstopではなく輸送ライン上にあるべきです"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
-msgstr "lineのバリアントがどのlineにも属していません、route_master relationに追加します"
+msgstr ""
+"lineのバリアントがどのlineにも属していません、route_master relationに追加しま"
+"す"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr "stopは任意のlineとして提供されていません、route relationに追加します"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "public_transportタグが公共交通機関の停止場所にない "
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr "停止場所 (platform)または鉄道上の停止位置(stop_position)を指定します"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "公共交通機関の停止場所に旧式のタグがない"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "networkタグはrouteとroute_masterで同じであるべきです: {0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr "operatorタグはrouteとroute_masterで同じであるべきです: {0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr "refタグはrouteとroute_masterで同じであるべきです: {0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "colourタグはrouteとroute_masterで同じであるべきです: {0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
-msgstr "public transport modeはroute及びroute_masterと同じであるべきです : {0} vs {1}"
+msgstr ""
+"public transport modeはroute及びroute_masterと同じであるべきです : {0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "colourタグをチェックしてください"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "カラーコードは'#'から始まり、続けて16進数の3または6桁であるべきです"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "公共交通機関のラインカラーはcolourタグにあるべきです"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "バス停はノードであることが想定されています"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "intervalが無効です(分指定で試してください)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "durationが無効です(分指定で試してください)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "主intervalを指定するintervalタグがない"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "opening_hoursタグがない"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "公共交通機関の停止場所にnameがない"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr "operatorタグを確認: このoperatorは存在せず、typoかもしれません"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr "networkタグを確認 : このnetworkは存在せずtypoかもしれません"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
-msgstr "バス・ステーションは通常多くのバスが停まる大きなエリアです、このエリアを描けるかどうか確認してください"
+msgstr ""
+"バス・ステーションは通常多くのバスが停まる大きなエリアです、このエリアを描け"
+"るかどうか確認してください"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
-msgstr "このstopはバス用ですかトラム用ですか？platformの種類を詳述するタグを追加します"
+msgstr ""
+"このstopはバス用ですかトラム用ですか？platformの種類を詳述するタグを追加しま"
+"す"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "地下鉄の入口はノードでマッピングします"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr "駅の入口は建物または道路(steps, footway, etc)の一部であるべきです"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # Jo <winfixit@gmail.com>, 2018
@@ -6,83 +6,68 @@
 # d8c0ea79bf25224e2a05d5edf10ab5e4_c9b605c, 2019
 # Ali z <ali.zaroili@outlook.be>, 2021
 # danieldegroot2 <danieldegroot18@gmail.com>, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: danieldegroot2 <danieldegroot18@gmail.com>, 2022\n"
-"Language-Team: Dutch (https://www.transifex.com/openstreetmap-france/teams/17462/nl/)\n"
+"Language-Team: Dutch (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/nl/)\n"
 "Language: nl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Compromisloze validatie van transit data"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr ""
 "Soort vervoermiddel ontbreekt , voeg een tag route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Soort vervoermiddel ontbreekt , verander tag route in route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "public_transport:version tag ontbreekt op een public_transport route relatie"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "network tag op public_transport relatie ontbreekt"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "operator tag op public_transport relatie ontbreekt"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "ref tag voor lijn nummer ontbreekt op een public_transport relatie"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "from/to tag op een public_transport weg relatie ontbreekt"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "De haltes staan misschien niet in de juiste volgorde"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Is dit een bushalte of een busstation?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Specifieer of het om een halte (platform) of om een stoppositie gaat "
 "(stop_position)."
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Is dit een bushalte?   tag highway=bus_stop toevoegen"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Controleer of de nota verwijderd kan worden"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "Het netwerk moet op de transport lijn en niet op de halte's"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "De beheerder moet op de transport lijn en niet op de halte's"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -90,58 +75,47 @@ msgstr ""
 "Deze routerelatie behoort bij geen enkele lijn, voeg toe bij route_master "
 "relatie "
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr "De halte is niet in gebruik, voeg dit toe bij relatie route"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "public_transport tag ontbreekt op een public transport halte"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Specifieer of het om een halte (platform) of om een stoppositie op de rails "
 "gaat (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "legacy tag op een  public transport halte ontbreekt"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"Het netwerk tag moet dezelfde zijn voor de route en de route_master : {0} vs"
-" {1}"
+"Het netwerk tag moet dezelfde zijn voor de route en de route_master : {0} vs "
+"{1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "De beheerder tag moet dezelfde zijn voor de route en de route_master : {0} "
 "vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr ""
 "De ref tag moet dezelfde zijn voor de route en de route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"De kleur tag moet dezelfde zijn voor de route en de route_master : {0} vs "
-"{1}"
+"De kleur tag moet dezelfde zijn voor de route en de route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -149,56 +123,43 @@ msgstr ""
 "Het openbaar vervoer mode moet dezelfde zijn voor de route en de "
 "route_master : {0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr " Controleer de kleur tag "
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "De colour code moet starten met '#' gevolgd door 3 of 6 nummers"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "De kleur van een openbaar vervoer lijn moet in een colour tag"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Een bushalte wordt verondersteld een node te zijn"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "De interval is ongeldig (probeer een nummer of minuten)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "De duur is ongeldig (probeer een nummer of minuten) "
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Ontbrekende interval tag om de hoofdinterval te specificeren"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr " opening_hours tag ontbreekt"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Naam op een  public transport halte ontbreekt"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Check dee operator tag : deze beheerder bestaaat niet, het is wellicht een "
 "typefout"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Check deze network tag : deze netwerk bestaaat niet, het is wellicht een "
 "typefout"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -206,16 +167,12 @@ msgstr ""
 "Een busstation is gebruikelijk een groot gebied waar veel bussen stoppen, "
 "controleer of u dit gebied kan tekenen"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
-msgstr ""
-"Is dit een bus- of tramhalte? Voeg een tag toe met het juiste platform"
+msgstr "Is dit een bus- of tramhalte? Voeg een tag toe met het juiste platform"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Metro-ingangen zouden als knopen in kaart gebracht moeten worden"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
@@ -223,10 +180,9 @@ msgstr ""
 "De stationsingang zou deel moeten uitmaken van een gebouw of een weg (trap, "
 "voetpad, etc)"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"
 msgstr ""
-"De stationsingang zou deel moeten uitmaken van een station: voeg het toe aan"
-" een stop_area relatie"
+"De stationsingang zou deel moeten uitmaken van een station: voeg het toe aan "
+"een stop_area relatie"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,140 +1,117 @@
-# 
+#
 # Translators:
 # maro21 OSM, 2021
 # Dave Ska, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Dave Ska, 2022\n"
-"Language-Team: Polish (https://www.transifex.com/openstreetmap-france/teams/17462/pl/)\n"
+"Language-Team: Polish (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/pl/)\n"
 "Language: pl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
+"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
+"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Bezkompromisowa walidacja danych przewozowych"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "Brak środka transportu, dodaj tag route=bus/tram/coach itp."
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Zmień tag route na route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
-msgstr ""
-"Relacji transportu publicznego brakuje tagu „public_transport:version”"
+msgstr "Relacji transportu publicznego brakuje tagu „public_transport:version”"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Relacji transportu publicznego brakuje tagu „network”"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Relacji transportu publicznego brakuje tagu „operator”"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Relacji transportu publicznego brakuje tagu „ref” (numer linii)"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Relacji transportu publicznego brakuje tagu „from” lub „to”"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Przystanki mogą być w niewłaściwej kolejności"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "To przystanek czy dworzec autobusowy?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
-"Określ, czy jest to przystanek (platform), czy miejsce zatrzymania na drodze"
-" (stop_position)"
+"Określ, czy jest to przystanek (platform), czy miejsce zatrzymania na drodze "
+"(stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Czy to przystanek autobusowy? Dodaj tag highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Sprawdź, czy tag note można usunąć"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr ""
 "Tag network powinien być na liniach transportu publicznego, nie na "
 "przystankach (dotyczy Francji)"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr ""
 "Tag operator powinien być na liniach transportu publicznego, nie na "
 "przystankach (dotyczy Francji)"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
-"Ten wariant linii transportu publicznego nie jest przyporządkowany do żadnej"
-" linii, dodaj go do relacji route_master"
+"Ten wariant linii transportu publicznego nie jest przyporządkowany do żadnej "
+"linii, dodaj go do relacji route_master"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Ten przystanek nie jest obsługiwany przez żadną linię, dodaj go do relacji "
 "trasy"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Przystankowi brakuje tagu „public_transport”"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Określ, czy jest to peron (platform), czy miejsce zatrzymania na torach "
 "(stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Brak podstawowego znacznika przystanku"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
-"Tag network powinien być taki sam w relacji route jak i route_master: {0} vs"
-" {1}"
+"Tag network powinien być taki sam w relacji route jak i route_master: {0} vs "
+"{1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Tag operator powinien być taki sam w relacji route jak i route_master: {0} "
 "vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr ""
 "Tag ref powinien być taki sam w relacji route jak i route_master: {0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -142,7 +119,6 @@ msgstr ""
 "Tag colour powinien być taki sam w relacji route jak i route_master: {0} vs "
 "{1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -150,54 +126,41 @@ msgstr ""
 "Środek transportu powinien być taki sam w relacji route jak i route_master: "
 "{0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Sprawdź tag colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Kod koloru powinien zaczynać się od \"#\" i mieć 3 lub 6 cyfr"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr ""
 "Kolor linii transportu publicznego powinien być w tagu „colour”, nie „color”"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Przystanek autobusowy powinien być węzłem"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "Przedział jest niepoprawny (wpisz liczbę minut, np. 15 lub 00:15:00)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr ""
 "Czas trwania jest niepoprawny (wpisz liczbę minut, np. 15 lub 00:15:00)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Brak tagu \"interval\". Określ podstawowy przedział"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Brak znacznika opening_hours"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Brak nazwy przystanku"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr "Sprawdź tag \"operator\": ten zarządca nie istnieje, może to literówka"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr "Sprawdź tag \"network\": ta sieć nie istnieje, może to literówka"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -205,15 +168,12 @@ msgstr ""
 "Dworzec autobusowy to zwykle duży obszar, gdzie zatrzymuje się wiele "
 "autobusów, spróbuj go narysować"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr "Dodaj highway=bus_stop lub tram=yes"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Wejścia do metra powinny być oznaczone jako węzły"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
@@ -221,7 +181,6 @@ msgstr ""
 "Wejście do stacji powinno być częścią budynku lub drogi (schody, chodnik "
 "itp.)"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,112 +1,91 @@
-# 
+#
 # Translators:
 # Ivan <freeExec@mail.ru>, 2020
 # Андрей Коваленко, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Андрей Коваленко, 2020\n"
-"Language-Team: Russian (https://www.transifex.com/openstreetmap-france/teams/17462/ru/)\n"
+"Language-Team: Russian (https://www.transifex.com/openstreetmap-france/"
+"teams/17462/ru/)\n"
 "Language: ru\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Валидатор транспорта"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "Не указан вид транспорта, добавьте route = bus/subway/tram/другое"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Не указан вид транспорта, поменяйте route на route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Отсутствует тег public_transport:version в отношение маршрута "
 "public_transport"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Отсутствует тег network в отношение маршрута public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Отсутствует тег operator в отношение маршрута public_transport"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Отсутствует тег ref  для номера маршрута в отношение public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Отсутствуют теги form/to в отношение маршрута public_transport"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "Остановки могут быть не в правильном порядке"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Это автобусная остановка или автостанция?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
-"Уточните назначение: остановка (platform) или место на дороге "
-"(stop_position)"
+"Уточните назначение: остановка (platform) или место на дороге (stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Это автобусная остановка? Добавь тег highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Проверь может ли заметка быть удалена"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "network должен быть на линии маршрута, а не остановок"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "operator должен быть на линии маршрута, а не остановок"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr "Вариант линии не фходит ни в одну линию. Добавте её в мастер-машрут"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Остановка не обслуживается ни одной линией, добавьте ее в отношение маршрута"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr ""
 "Отсутствует тег public_transport на месте остановки общественного транспорта"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Уточните назначение: платформа (platform) или точка на путях (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
-msgstr ""
-"Отсутствует устаревший тег на месте остановки общественного транспорта"
+msgstr "Отсутствует устаревший тег на месте остановки общественного транспорта"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -114,15 +93,13 @@ msgstr ""
 "Теги network у маршрута и мастер-маршрута должны совпадать:route {0}, а "
 "route_master {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Теги operator у маршрута и мастер-маршрута должны совпадать:route {0}, а "
 "route_master {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
@@ -130,7 +107,6 @@ msgstr ""
 "Теги ref у маршрута и мастер-маршрута должны совпадать:route {0}, а "
 "route_master {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -138,7 +114,6 @@ msgstr ""
 "Теги colour у маршрута и мастер-маршрута должны совпадать:route {0}, а "
 "route_master {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -146,53 +121,40 @@ msgstr ""
 "Вид транспорта у маршрута и мастер-маршрута должны совпадать:route {0}, а "
 "route_master {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Проверьте тег colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "colour должен начинаться с '#' и далее 3 или 6 цифр"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "Цвет линии общественного транспорта должен быть в теге colour"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Автобусная остановка должна быть точкой"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "Интервал не корректный (попробуйте число в минутах)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "Продолжительность не корректная (попробуйте число в минутах)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Отсутствует тег interval для задания главного интервала движения"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Отсутствует тег opening_hours"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Отсутствует название остановки"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Проверьте тег operator: этот оператор не существует, возможно там опечатка"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr "Проверьте тег network: эта сеть не существует, возможно там опечатка"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -200,23 +162,19 @@ msgstr ""
 "Автовокзал - это как правило большая территория, где останавливаются много "
 "автобусов, проверьте, можете ли вы нарисовать  эту территорию"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr ""
 "Это автобусная или трамвайная остановка? Добавьте тег, уточняющий тип "
 "платформы"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/transport_mapcss.pot
+++ b/po/transport_mapcss.pot
@@ -1,68 +1,68 @@
-#: ../transport.validator.mapcss:15
+#: ../transport.validator.mapcss:16
 msgid "Uncompromising validation of transit data"
 msgstr "Uncompromising validation of transit data"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
+#: ../transport.validator.mapcss:70 ../transport.validator.mapcss:80
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
+#: ../transport.validator.mapcss:86
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Missing transportation mode, change tag route to route_master"
 
-#: ../transport.validator.mapcss:91
+#: ../transport.validator.mapcss:102
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Missing public_transport:version tag on a public_transport route relation"
 
-#: ../transport.validator.mapcss:100
+#: ../transport.validator.mapcss:111
 msgid "Missing network tag on a public_transport relation"
 msgstr "Missing network tag on a public_transport relation"
 
-#: ../transport.validator.mapcss:109
+#: ../transport.validator.mapcss:120
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Missing operator tag on a public_transport relation"
 
-#: ../transport.validator.mapcss:118
+#: ../transport.validator.mapcss:129
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Missing ref tag for line number on a public_transport relation"
 
-#: ../transport.validator.mapcss:127
+#: ../transport.validator.mapcss:138
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Missing from/to tag on a public_transport route relation"
 
-#: ../transport.validator.mapcss:184
+#: ../transport.validator.mapcss:203
 msgid "The stops may not be in the right order"
 msgstr "The stops may not be in the right order"
 
-#: ../transport.validator.mapcss:209
+#: ../transport.validator.mapcss:241
 msgid "Is it a bus stop or a bus station?"
 msgstr "Is it a bus stop or a bus station?"
 
-#: ../transport.validator.mapcss:221
+#: ../transport.validator.mapcss:253
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 
-#: ../transport.validator.mapcss:250
+#: ../transport.validator.mapcss:287
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Is this a bus stop? add the tag highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
+#: ../transport.validator.mapcss:298
 msgid "Check if the note can be deleted"
 msgstr "Check if the note can be deleted"
 
-#: ../transport.validator.mapcss:266
+#: ../transport.validator.mapcss:303
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "The network should be on the transport lines and not on the stops"
 
-#: ../transport.validator.mapcss:272
+#: ../transport.validator.mapcss:309
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "The operator should be on the transport lines and not on the stops"
 
-#: ../transport.validator.mapcss:283
+#: ../transport.validator.mapcss:320
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
@@ -70,25 +70,25 @@ msgstr ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 
-#: ../transport.validator.mapcss:297
+#: ../transport.validator.mapcss:331
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr "The stop is not served by any line, add it to a route relation"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
+#: ../transport.validator.mapcss:254 ../transport.validator.mapcss:265
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Missing public_transport tag on a public transport stop"
 
-#: ../transport.validator.mapcss:232
+#: ../transport.validator.mapcss:264
 msgid ""
 "Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr ""
 "Specify if it is a stop (platform) or a location on the rails (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
+#: ../transport.validator.mapcss:281 ../transport.validator.mapcss:288
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Missing legacy tag on a public transport stop"
 
-#: ../transport.validator.mapcss:137
+#: ../transport.validator.mapcss:148
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -96,7 +96,7 @@ msgstr ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 
-#: ../transport.validator.mapcss:142
+#: ../transport.validator.mapcss:153
 msgid ""
 "The operator tag should be the same for the route and the route_master : {0} "
 "vs {1}"
@@ -104,76 +104,76 @@ msgstr ""
 "The operator tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 
-#: ../transport.validator.mapcss:147
+#: ../transport.validator.mapcss:158
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
-
-#: ../transport.validator.mapcss:152
-msgid ""
-"The colour tag should be the same for the route and the route_master : {0} "
-"vs {1}"
-msgstr ""
-"The colour tag should be the same for the route and the route_master : {0} "
-"vs {1}"
-
-#: ../transport.validator.mapcss:157
-msgid ""
-"The public transport mode should be the same for the route and the "
-"route_master : {0} vs {1}"
-msgstr ""
-"The public transport mode should be the same for the route and the "
-"route_master : {0} vs {1}"
 
 #: ../transport.validator.mapcss:163
+msgid ""
+"The colour tag should be the same for the route and the route_master : {0} "
+"vs {1}"
+msgstr ""
+"The colour tag should be the same for the route and the route_master : {0} "
+"vs {1}"
+
+#: ../transport.validator.mapcss:168
+msgid ""
+"The public transport mode should be the same for the route and the "
+"route_master : {0} vs {1}"
+msgstr ""
+"The public transport mode should be the same for the route and the "
+"route_master : {0} vs {1}"
+
+#: ../transport.validator.mapcss:178
 msgid "Check the colour tag"
 msgstr "Check the colour tag"
 
-#: ../transport.validator.mapcss:170
+#: ../transport.validator.mapcss:189
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "The colour code should start with '#' followed by 3 or 6 digits"
 
-#: ../transport.validator.mapcss:178
+#: ../transport.validator.mapcss:197
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "The color of the public transport line should be in a colour tag"
 
-#: ../transport.validator.mapcss:204
+#: ../transport.validator.mapcss:231
 msgid "A bus stop is supposed to be a node"
 msgstr "A bus stop is supposed to be a node"
 
-#: ../transport.validator.mapcss:316
+#: ../transport.validator.mapcss:349
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "The interval is invalid (try a number of minutes)"
 
-#: ../transport.validator.mapcss:332
+#: ../transport.validator.mapcss:369
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "The duration is invalid (try a number of minutes)"
 
-#: ../transport.validator.mapcss:345
+#: ../transport.validator.mapcss:386
 msgid "Missing interval tag to specify the main interval"
 msgstr "Missing interval tag to specify the main interval"
 
-#: ../transport.validator.mapcss:351
+#: ../transport.validator.mapcss:396
 msgid "Missing opening_hours tag"
 msgstr "Missing opening_hours tag"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
+#: ../transport.validator.mapcss:338
 msgid "Missing name on a public transport stop"
 msgstr "Missing name on a public transport stop"
 
-#: ../transport.validator.mapcss:192
+#: ../transport.validator.mapcss:215
 msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Check the operator tag : this operator does not exist, it may be a typo"
 
-#: ../transport.validator.mapcss:198
+#: ../transport.validator.mapcss:225
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr "Check the network tag : this network does not exist, it may be a typo"
 
-#: ../transport.validator.mapcss:215
+#: ../transport.validator.mapcss:247
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
@@ -181,15 +181,15 @@ msgstr ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
 
-#: ../transport.validator.mapcss:243
+#: ../transport.validator.mapcss:280
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 
-#: ../transport.validator.mapcss:359
+#: ../transport.validator.mapcss:404
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Subway entrances should be mapped as nodes"
 
-#: ../transport.validator.mapcss:391
+#: ../transport.validator.mapcss:449
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
@@ -197,7 +197,7 @@ msgstr ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 
-#: ../transport.validator.mapcss:375
+#: ../transport.validator.mapcss:433
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,137 +1,113 @@
-# 
+#
 # Translators:
 # Green Aloe, 2022
 # VARVAR <182050@i.ua>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: VARVAR <182050@i.ua>, 2023\n"
-"Language-Team: Ukrainian (https://app.transifex.com/openstreetmap-france/teams/17462/uk/)\n"
+"Language-Team: Ukrainian (https://app.transifex.com/openstreetmap-france/"
+"teams/17462/uk/)\n"
 "Language: uk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "Безкомпромісна перевірка транзитних даних"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
-msgstr ""
-"Відсутній режим транспортування, додайте теґ route=bus/coach/tram/тощо"
+msgstr "Відсутній режим транспортування, додайте теґ route=bus/coach/tram/тощо"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "Відсутній режим транспортування, змініть теґ route на route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr ""
 "Відсутній теґ public_transport:version на звʼязку маршруту громадського "
 "транспорту"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "Відсутній теґ network на звʼязку public_transport"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "Відсутній теґ operator у звʼязку громадського транспорту"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "Відсутній теґ ref для номеру лінії на звʼязку public_transport"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "Відсутній теґ from/to у звʼязку маршруту громадського транспорту"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "The stops may not be in the right order"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "Це автобусна зупинка чи автовокзал?"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr "Вкажіть, це зупинка (платформа), чи місце на шляху (stop_position)"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "Це автобусна зупинка? додайте теґ highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "Перевірте, чи можна видалити нотатку"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "Network повинен бути на транспортних лініях, а не на зупинках"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "Operator повинен бути на транспортних лініях, а не на зупинках"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr ""
 "Варіант лінії не належить жодній лінії, додайте його до звʼязку route_master"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr ""
 "Зупинка не обслуговується жодною лінією, додайте її до звʼязку маршруту"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "Відсутній теґ public_transport на public_transport_stop"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
-msgstr ""
-"Вкажіть, чи це зупинка (платформа), чи місце на рейках (stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
+msgstr "Вкажіть, чи це зупинка (платформа), чи місце на рейках (stop_position)"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "Відсутній теґ legacy на public_transport_stop"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 "Теґ network має бути однаковим для route та route_master : {0} проти {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr ""
 "Теґ operator має бути однаковим для route та route_master : {0} проти {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr "Теґ ref має бути однаковим для route та route_master : {0} проти {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr ""
 "Теґ colour має бути однаковим для route та route_master : {0} проти {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
@@ -139,80 +115,62 @@ msgstr ""
 "Режим public transport має бути однаковим для route та route_master : {0} "
 "проти {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "Перевірте теґ colour"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "Код colour має починатися символом '#', за яким стоять 3, або 6 цифр"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "Колір лінії громадського транспорту повинен мати теґ colour"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "Зупинка автобуса повинна бути точкою"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "Недійсний інтервал (вкажіть кількість хвилин)"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "Недійсна тривалість (вкажіть кількість хвилин)"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "Відсутній теґ interval для вказання основного інтервалу"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "Відсутній теґ opening_hours"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "Відсутня назва зупинки громадського транспорту"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr ""
 "Перевірте теґ operator: такого оператора не існує, або може бути "
 "орфоргафічною помилкою"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr ""
 "Перевірте теґ network: цієї мережі не існує, або може бути орфоргафічною "
 "помилкою"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
 msgstr ""
-"Автобусна станція -  це, як правило, велика територія, де зупиняється багато"
-" автобусів, перевірте, чи можна накреслити цю зону"
+"Автобусна станція -  це, як правило, велика територія, де зупиняється багато "
+"автобусів, перевірте, чи можна накреслити цю зону"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr "Це зупинка автобуса чи трамваю? Додайте теґ точного виду платформи"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "Входи в метро повинні бути нанесені на карту як точки"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr ""
-"Вхід до станції повинен бути частиною будівлі або шляху (сходи, хідник, "
-"тощо)"
+"Вхід до станції повинен бути частиною будівлі або шляху (сходи, хідник, тощо)"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,200 +1,158 @@
-# 
+#
 # Translators:
 # frodrigo <fred.rodrigo@gmail.com>, 2018
 # jie x, 2018
 # anodern, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: anodern, 2021\n"
-"Language-Team: Chinese (China) (https://www.transifex.com/openstreetmap-france/teams/17462/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/openstreetmap-"
+"france/teams/17462/zh_CN/)\n"
 "Language: zh_CN\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
 msgstr "运输数据不妥协的验证"
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
 msgstr "缺少运输模式，请添加标签route = bus/coach/tram/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
 msgstr "缺少运输模式，请将标签路线更改为route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
 msgstr "缺少public_transport：public_transport路径关系上的版本标记"
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
 msgstr "在public_transport关系中缺少网络标记"
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
 msgstr "在public_transport关系中缺少运运营单位标记"
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
 msgstr "在public_transport关系中缺少线路编号的ref标记"
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
 msgstr "在public_transport路径关系上缺少from/to标签"
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
 msgstr "站点可能没有按照正确的顺序"
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
 msgstr "它是一个公交站还是一个公交总站？"
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
 msgstr "指定它是停靠点（站台）还是道路上的位置（stop_position）"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
 msgstr "这是公交站吗？ 添加标签highway=bus_stop"
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
 msgstr "检查笔记是否可以删除"
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
 msgstr "交通系统network标签应该在交通线路上，而不是在停靠点上"
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
 msgstr "运营商标签应该在交通线路上，而不是在停靠站上"
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
 msgstr "线型不属于任何线路，将其添加到route_master关系中"
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
 msgstr "停靠点不是为任何线路服务的，将其添加到路线关系中"
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
 msgstr "公共交通站点缺少public_transport标记"
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
 msgstr "指定它是停靠点（站台）还是位于铁轨上的位置（stop_position）"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
 msgstr "公共交通站点缺少传统标签"
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "路线和主路线的网络标签应一致：{0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
 msgstr "路线和主路线的运营者标签应一致：{0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
 msgstr "路线和主路线的编号标签应一致：{0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
 msgstr "路线和主路线的颜色标签应一致：{0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
 msgstr "路线和主路线的公共交通模式标签应一致：{0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
 msgstr "检查颜色标签"
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
 msgstr "颜色代码应以'#'开头，后接3或6位16进制数字"
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
 msgstr "表示公共交通路线的颜色应使用colour标签"
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
 msgstr "公交停车点应绘制为点"
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
 msgstr "间隔时间无效（尝试使用多少分钟）"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
 msgstr "单程运行时间无效（尝试使用多少分钟）"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
 msgstr "缺少表示间隔的标签"
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
 msgstr "缺少运营时间标签"
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
 msgstr "公共交通站点缺少名称标签"
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
 msgstr "检查运营者标签：这个运营者不存在，可能是输入错误"
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
 msgstr "检查网络标签：这个网络不存在，可能是输入错误"
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
 msgstr "公交枢纽站通常是包含了很多公交站的大型区域，如果可以的话请绘制为区域"
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
 msgstr "这是公交站还是电车站？添加更精确的标记来描述站台的类型"
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
 msgstr "地铁出入口应绘制为点"
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
 msgstr "车站出入口应作为建筑或道路（steps, footway等）的一部分"
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,197 +1,155 @@
-# 
+#
 # Translators:
 # Supaplex <bejokeup@gmail.com>, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Supaplex <bejokeup@gmail.com>, 2022\n"
-"Language-Team: Chinese (Taiwan) (https://www.transifex.com/openstreetmap-france/teams/17462/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/openstreetmap-"
+"france/teams/17462/zh_TW/)\n"
 "Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../transport.validator.mapcss:15
 msgid "Uncompromising validation of transit data"
-msgstr "未妥協驗證的運輸資料"
+msgstr ""
 
-#: ../transport.validator.mapcss:64 ../transport.validator.mapcss:69
 msgid "Missing transportation mode, add a tag route = bus/coach/tram/etc"
-msgstr "遺失交通模式，請加上標籤如 route = bus/coach/tran/etc"
+msgstr " route = bus/coach/tran/etc"
 
-#: ../transport.validator.mapcss:75
 msgid "Missing transportation mode, change tag route to route_master"
-msgstr "遺失交通模式，請更改標籤從 route 到 route_master"
+msgstr " route  route_master"
 
-#: ../transport.validator.mapcss:91
 msgid ""
 "Missing public_transport:version tag on a public_transport route relation"
-msgstr "public_transport 路線關聯遺失 public_transport:version 標籤"
+msgstr "public_transport  public_transport:version "
 
-#: ../transport.validator.mapcss:100
 msgid "Missing network tag on a public_transport relation"
-msgstr "public_transport 關聯遺失網路標籤"
+msgstr "public_transport "
 
-#: ../transport.validator.mapcss:109
 msgid "Missing operator tag on a public_transport relation"
-msgstr "public_transport 關聯遺失營業者標籤"
+msgstr "public_transport "
 
-#: ../transport.validator.mapcss:118
 msgid "Missing ref tag for line number on a public_transport relation"
-msgstr "public_transport 關聯遺失路線號碼 ref 標籤"
+msgstr "public_transport  ref "
 
-#: ../transport.validator.mapcss:127
 msgid "Missing from/to tag on a public_transport route relation"
-msgstr "public_transport 路線關聯遺失 from/to 標籤"
+msgstr "public_transport  from/to "
 
-#: ../transport.validator.mapcss:184
 msgid "The stops may not be in the right order"
-msgstr "站牌並不是對的順序"
+msgstr ""
 
-#: ../transport.validator.mapcss:209
 msgid "Is it a bus stop or a bus station?"
-msgstr "這是公車站牌還是公車轉運站"
+msgstr ""
 
-#: ../transport.validator.mapcss:221
 msgid ""
 "Specify if it is a stop (platform) or a location on the road (stop_position)"
-msgstr "請指明是站牌 (月台) 或是路線上的位置 (停車位置)"
+msgstr " ()  ()"
 
-#: ../transport.validator.mapcss:250
 msgid "Is this a bus stop? add the tag highway=bus_stop"
-msgstr "這是公車站牌？請加上 highway=bus_stop 標籤"
+msgstr " highway=bus_stop "
 
-#: ../transport.validator.mapcss:261
 msgid "Check if the note can be deleted"
-msgstr "檢查註解是否能移除"
+msgstr ""
 
-#: ../transport.validator.mapcss:266
 msgid "The network should be on the transport lines and not on the stops"
-msgstr "網路應該在交通路線上而不是站牌"
+msgstr ""
 
-#: ../transport.validator.mapcss:272
 msgid "The operator should be on the transport lines and not on the stops"
-msgstr "營運者應該在交通路線上而不是站牌"
+msgstr ""
 
-#: ../transport.validator.mapcss:283
 msgid ""
 "The line variant does not belong to any line, add it to the route_master "
 "relation"
-msgstr "差異路線並不屬於任何路線，請加到 route_master 關聯中"
+msgstr " route_master "
 
-#: ../transport.validator.mapcss:297
 msgid "The stop is not served by any line, add it to a route relation"
-msgstr "站牌並沒有服務任何路線，請加到 route 關聯"
+msgstr " route "
 
-#: ../transport.validator.mapcss:222 ../transport.validator.mapcss:233
 msgid "Missing public_transport tag on a public transport stop"
-msgstr "大眾運輸站點遺失 public_transport 標籤"
+msgstr " public_transport "
 
-#: ../transport.validator.mapcss:232
 msgid ""
-"Specify if it is a stop (platform) or a location on the rails "
-"(stop_position)"
-msgstr "請指明是車站 (月台) 或是鐵軌上的位置 (停車位置)"
+"Specify if it is a stop (platform) or a location on the rails (stop_position)"
+msgstr " ()  ()"
 
-#: ../transport.validator.mapcss:244 ../transport.validator.mapcss:251
 msgid "Missing legacy tag on a public transport stop"
-msgstr "大眾運輸站點遺失傳統標籤"
+msgstr ""
 
-#: ../transport.validator.mapcss:137
 msgid ""
 "The network tag should be the same for the route and the route_master : {0} "
 "vs {1}"
-msgstr "路線和路線總纜的網路標籤應該是相同的：{0} vs {1}"
+msgstr "{0} vs {1}"
 
-#: ../transport.validator.mapcss:142
 msgid ""
-"The operator tag should be the same for the route and the route_master : {0}"
-" vs {1}"
-msgstr "路線和路線總纜的營運者標籤應該是相同的：{0} vs {1}"
+"The operator tag should be the same for the route and the route_master : {0} "
+"vs {1}"
+msgstr "{0} vs {1}"
 
-#: ../transport.validator.mapcss:147
 msgid ""
 "The ref tag should be the same for the route and the route_master : {0} vs "
 "{1}"
-msgstr "路線和路線總纜的編號標籤應該是相同的：{0} vs {1}"
+msgstr "{0} vs {1}"
 
-#: ../transport.validator.mapcss:152
 msgid ""
 "The colour tag should be the same for the route and the route_master : {0} "
 "vs {1}"
-msgstr "路線和路線總纜的顏色標籤應該是相同的：{0} vs {1}"
+msgstr "{0} vs {1}"
 
-#: ../transport.validator.mapcss:157
 msgid ""
 "The public transport mode should be the same for the route and the "
 "route_master : {0} vs {1}"
-msgstr "路線和路線總纜的大眾運輸模式標籤應該是相同的：{0} vs {1}"
+msgstr "{0} vs {1}"
 
-#: ../transport.validator.mapcss:163
 msgid "Check the colour tag"
-msgstr "檢查顏色標籤"
+msgstr ""
 
-#: ../transport.validator.mapcss:170
 msgid "The colour code should start with '#' followed by 3 or 6 digits"
-msgstr "顏色代碼應該以  '#' 開頭後面接 3 或 6 個數字"
+msgstr "  '#'  3  6 "
 
-#: ../transport.validator.mapcss:178
 msgid "The color of the public transport line should be in a colour tag"
-msgstr "大眾運輸路線的顏色應當用顏色標籤"
+msgstr ""
 
-#: ../transport.validator.mapcss:204
 msgid "A bus stop is supposed to be a node"
-msgstr "公車站應當是節點"
+msgstr ""
 
-#: ../transport.validator.mapcss:316
 msgid "The interval is invalid (try a number of minutes)"
-msgstr "時間區間無效 (試試用多少分鐘)"
+msgstr " ()"
 
-#: ../transport.validator.mapcss:332
 msgid "The duration is invalid (try a number of minutes)"
-msgstr "單程時間無效 (試試用多少分鐘)"
+msgstr " ()"
 
-#: ../transport.validator.mapcss:345
 msgid "Missing interval tag to specify the main interval"
-msgstr "遺失的時間區間標籤來指明主要的時間區間"
+msgstr ""
 
-#: ../transport.validator.mapcss:351
 msgid "Missing opening_hours tag"
-msgstr "缺少開放時間標籤"
+msgstr ""
 
-#: ../transport.validator.mapcss:303 ../transport.validator.mapcss:309
 msgid "Missing name on a public transport stop"
-msgstr "大眾運輸站點遺失名稱"
+msgstr ""
 
-#: ../transport.validator.mapcss:192
-msgid ""
-"Check the operator tag : this operator does not exist, it may be a typo"
-msgstr "檢查營運者標籤：營運者並不存在，也許打錯了"
+msgid "Check the operator tag : this operator does not exist, it may be a typo"
+msgstr ""
 
-#: ../transport.validator.mapcss:198
 msgid "Check the network tag : this network does not exist, it may be a typo"
-msgstr "檢查路線網路標籤：路線網路並不存在，也許打錯了"
+msgstr ""
 
-#: ../transport.validator.mapcss:215
 msgid ""
 "A bus station is usually a large area where many buses stop, check if you "
 "can draw this area"
-msgstr "轉運站通常是大型區域，擁有多個公車站，如果可能請用區域來描繪"
+msgstr ""
 
-#: ../transport.validator.mapcss:243
 msgid "Is this a bus or tram stop ? Add a tag to precise the kind of platform"
-msgstr "這是公車站還是街車站？請加精準的標籤來描述等車區"
+msgstr ""
 
-#: ../transport.validator.mapcss:359
 msgid "Subway entrances should be mapped as nodes"
-msgstr "捷運出口應該標為節點"
+msgstr ""
 
-#: ../transport.validator.mapcss:391
 msgid ""
 "The station entrance should be part of a building or a highway (steps, "
 "footway, etc)"
-msgstr "車站出入口應當是建築或是路徑 (樓梯、步道等) 的一部分。"
+msgstr " () "
 
-#: ../transport.validator.mapcss:375
 msgid ""
 "The station entrance should be in part of a station: add it to a stop_area "
 "relation"
-msgstr "車站出入口應當是車站的一部分：而且也該是 stop_area 關係的一部分"
+msgstr " stop_area "

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -320,13 +320,10 @@ node.ptv2_platform[!highway][!railway][bus=yes]
 	throwError: tr("The line variant does not belong to any line, add it to the route_master relation");
 }
 
-*.route > node.ptv2_platform
-{
-	set platform_in_route
-}
+*.route > node.ptv2_platform,
 *.route > way.ptv2_platform
 {
-	set way_platform_in_route
+	set platform_in_route
 }
 
 node.ptv2_platform!.platform_in_route
@@ -335,13 +332,8 @@ node.ptv2_platform!.platform_in_route
 	-osmoseItemClassLevel: none;
 }
 
-node.platform_in_route[!name]
-{
-	throwWarning: tr("Missing name on a public transport stop");
-	-osmoseItemClassLevel: none;
-}
-
-way.way_platform_in_route[!name]
+node.platform_in_route[!name],
+way.platform_in_route[!name]
 {
 	throwWarning: tr("Missing name on a public transport stop");
 	-osmoseItemClassLevel: none;

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -413,18 +413,22 @@ node[railway=subway_entrance]
 {
 	set subway_entrance
 }
+node[railway=train_station_entrance]
+{
+	set train_entrance
+}
 
 *.stop_area > *.subway_entrance
 {
 	set subway_entrance_in_stop_area
 }
-*.stop_area > node[railway=train_station_entrance]
+*.stop_area > *.train_entrance
 {
 	set train_station_entrance_in_stop_area
 }
 
 *.subway_entrance!.subway_entrance_in_stop_area,
-node[railway=train_station_entrance]!.train_station_entrance_in_stop_area
+*.train_entrance!.train_station_entrance_in_stop_area
 {
 	throwError: tr("The station entrance should be in part of a station: add it to a stop_area relation");
 	-osmoseItemClassLevel: none;
@@ -434,13 +438,13 @@ way > *.subway_entrance
 {
 	set subway_entrance_in_way
 }
-way > node[railway=train_station_entrance]
+way > *.train_entrance
 {
 	set train_station_entrance_in_way
 }
 
 *.subway_entrance!.subway_entrance_in_way,
-node[railway=train_station_entrance]!.train_station_entrance_in_way
+*.train_entrance!.train_station_entrance_in_way
 {
 	throwWarning: tr("The station entrance should be part of a building or a highway (steps, footway, etc)");
 	-osmoseItemClassLevel: none;

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -405,11 +405,16 @@ relation[railway=train_station_entrance]
 	assertMatch: "way railway=subway_entrance";
 }
 
-relation[public_transport=stop_area] > node[railway=subway_entrance]
+relation[public_transport=stop_area]
+{
+	set stop_area
+}
+
+*.stop_area > node[railway=subway_entrance]
 {
 	set subway_entrance_in_stop_area
 }
-relation[public_transport=stop_area] > node[railway=train_station_entrance]
+*.stop_area > node[railway=train_station_entrance]
 {
 	set train_station_entrance_in_stop_area
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -168,15 +168,23 @@ relation[type=route_master]
 	throwError: tr("The public transport mode should be the same for the route and the route_master : {0} vs {1}", tag(route), parent_tag(route_master));
 }
 
-*.pt_route[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
-*.pt_route_master[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+*[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+{
+	set bad_colour
+}
+*.pt_route.bad_colour,
+*.pt_route_master.bad_colour
 {
 	throwError: tr("Check the colour tag");
 	-osmoseItemClassLevel: none;
 }
 
-*.pt_route[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
-*.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+*[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+{
+	set colour_nohash
+}
+*.pt_route.colour_nohash,
+*.pt_route_master.colour_nohash
 {
 	throwError: tr("The colour code should start with '#' followed by 3 or 6 digits");
 	fixAdd: concat("colour=#", tag(colour));
@@ -197,14 +205,22 @@ relation[type=route_master]
 }
 
 /* These values are not valid operator or network */
-*.pt_route["operator"=~/STIF|Kéolis|Véolia/][inside("FR")],
-*.pt_route_master["operator"=~/STIF|Kéolis|Véolia/][inside("FR")]
+*["operator"=~/STIF|Kéolis|Véolia/][inside("FR")]
+{
+	set bad_operator
+}
+*.pt_route.bad_operator,
+*.pt_route_master.bad_operator
 {
 	throwError: tr("Check the operator tag : this operator does not exist, it may be a typo");
 }
 
-*.pt_route["network"=~/STIF|Kéolis|Véolia/][inside("FR")],
-*.pt_route_master["network"=~/STIF|Kéolis|Véolia/][inside("FR")]
+*["network"=~/STIF|Kéolis|Véolia/][inside("FR")]
+{
+	set bad_network
+}
+*.pt_route.bad_network,
+*.pt_route_master.bad_network
 {
 	throwError: tr("Check the network tag : this network does not exist, it may be a typo");
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -70,13 +70,18 @@ relation[type=route]
 	throwError: tr("Missing transportation mode, add a tag route = bus/coach/tram/etc");
 }
 
-relation[type=route_master][!route_master][!route][!disused:route_master]
+relation[type=route_master]
+{
+	set route_master
+}
+
+*.route_master[!route_master][!route][!disused:route_master]
 {
 	throwError: tr("Missing transportation mode, add a tag route = bus/coach/tram/etc");
 }
 
 /*the transport mode is specified with the wrong tag */
-relation[type=route_master][!route_master][route]
+*.route_master[!route_master][route]
 {
 	throwError: tr("Missing transportation mode, change tag route to route_master");
 	fixChangeKey: "route=>route_master";
@@ -87,7 +92,7 @@ relation[type=route_master][!route_master][route]
 	set pt_route;
 }
 
-relation[type=route_master][route_master=~/^(bus|coach|train|subway|monorail|trolleybus|aerialway|funicular|ferry|tram|share_taxi|light_rail|school_bus|walking_bus)$/]
+*.route_master[route_master=~/^(bus|coach|train|subway|monorail|trolleybus|aerialway|funicular|ferry|tram|share_taxi|light_rail|school_bus|walking_bus)$/]
 {
 	set pt_route_master;
 }
@@ -279,7 +284,7 @@ node[highway=bus_stop][operator][inside("FR")]
 	fixRemove: "operator";
 }
 
-relation[type=route_master] > *.route
+*.route_master > *.route
 {
 	set route_ok
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -1,6 +1,6 @@
 meta
 {
-	title: "Jungle Bus – validation ruleset";
+	title: "Jungle Bus - validation ruleset";
 	version: "0.12";
 	description: "Uncompromising validation of transit data";
 	author: "nlehuby";

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -270,14 +270,19 @@ node[railway=tram_stop][!public_transport]
 	assertMatch: "node railway=tram_stop";
 }
 
-node[public_transport=platform][!highway][!railway][!bus][!tram][!ferry][!walking_bus]
+*[public_transport=platform]
+{
+	set ptv2_platform
+}
+
+node.ptv2_platform[!highway][!railway][!bus][!tram][!ferry][!walking_bus]
 {
 	throwError: tr("Is this a bus or tram stop ? Add a tag to precise the kind of platform");
 	group: tr("Missing legacy tag on a public transport stop");
 	-osmoseItemClassLevel: "2140/21412:1/3";
 }
 
-node[public_transport=platform][!highway][!railway][bus=yes]
+node.ptv2_platform[!highway][!railway][bus=yes]
 {
 	throwError: tr("Is this a bus stop? add the tag highway=bus_stop");
 	group: tr("Missing legacy tag on a public transport stop");
@@ -315,16 +320,16 @@ node[public_transport=platform][!highway][!railway][bus=yes]
 	throwError: tr("The line variant does not belong to any line, add it to the route_master relation");
 }
 
-*.route > node[public_transport=platform]
+*.route > node.ptv2_platform
 {
 	set platform_in_route
 }
-*.route > way[public_transport=platform]
+*.route > way.ptv2_platform
 {
 	set way_platform_in_route
 }
 
-node[public_transport=platform]!.platform_in_route
+node.ptv2_platform!.platform_in_route
 {
 	throwError: tr("The stop is not served by any line, add it to a route relation");
 	-osmoseItemClassLevel: none;

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -97,7 +97,7 @@ relation[type=route_master]
 	set pt_route_master;
 }
 
-relation.pt_route[!public_transport:version]
+*.pt_route[!public_transport:version]
 {
 	throwError: tr("Missing public_transport:version tag on a public_transport route relation");
 	-osmoseItemClassLevel: "2140/21401/3";
@@ -105,7 +105,7 @@ relation.pt_route[!public_transport:version]
 	assertMatch: "relation type=route route=bus";
 }
 
-relation.pt_route[!network],
+*.pt_route[!network],
 relation.pt_route_master[!network]
 {
 	throwError: tr("Missing network tag on a public_transport relation");
@@ -114,7 +114,7 @@ relation.pt_route_master[!network]
 	assertMatch: "relation type=route route=bus";
 }
 
-relation.pt_route[!operator],
+*.pt_route[!operator],
 relation.pt_route_master[!operator]
 {
 	throwError: tr("Missing operator tag on a public_transport relation");
@@ -123,7 +123,7 @@ relation.pt_route_master[!operator]
 	assertMatch: "relation type=route route=bus";
 }
 
-relation.pt_route[!ref],
+*.pt_route[!ref],
 relation.pt_route_master[!ref]
 {
 	throwWarning: tr("Missing ref tag for line number on a public_transport relation");
@@ -132,8 +132,8 @@ relation.pt_route_master[!ref]
 	assertMatch: "relation type=route route=bus";
 }
 
-relation.pt_route[!from],
-relation.pt_route[!to]
+*.pt_route[!from],
+*.pt_route[!to]
 {
 	throwError: tr("Missing from/to tag on a public_transport route relation");
 	-osmoseItemClassLevel: "2140/21405/3";
@@ -143,39 +143,39 @@ relation.pt_route[!to]
 	assertMatch: "relation type=route route=bus";
 }
 
-relation.pt_route[tag(network)!=parent_tag(network)]
+*.pt_route[tag(network)!=parent_tag(network)]
 {
 	throwError: tr("The network tag should be the same for the route and the route_master : {0} vs {1}", tag(network), parent_tag(network));
 }
 
-relation.pt_route[tag(operator)!=parent_tag(operator)]
+*.pt_route[tag(operator)!=parent_tag(operator)]
 {
 	throwError: tr("The operator tag should be the same for the route and the route_master : {0} vs {1}", tag(operator), parent_tag(operator));
 }
 
-relation.pt_route[tag(ref)!=parent_tag(ref)]
+*.pt_route[tag(ref)!=parent_tag(ref)]
 {
 	throwWarning: tr("The ref tag should be the same for the route and the route_master : {0} vs {1}", tag(ref), parent_tag(ref));
 }
 
-relation.pt_route[tag(colour)!=parent_tag(colour)]
+*.pt_route[tag(colour)!=parent_tag(colour)]
 {
 	throwWarning: tr("The colour tag should be the same for the route and the route_master : {0} vs {1}", tag(colour), parent_tag(colour));
 }
 
-relation.pt_route[tag(route)!=parent_tag(route_master)]
+*.pt_route[tag(route)!=parent_tag(route_master)]
 {
 	throwError: tr("The public transport mode should be the same for the route and the route_master : {0} vs {1}", tag(route), parent_tag(route_master));
 }
 
-relation.pt_route[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
+*.pt_route[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
 relation.pt_route_master[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 {
 	throwError: tr("Check the colour tag");
 	-osmoseItemClassLevel: none;
 }
 
-relation.pt_route[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
+*.pt_route[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
 relation.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 {
 	throwError: tr("The colour code should start with '#' followed by 3 or 6 digits");
@@ -183,27 +183,27 @@ relation.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 	-osmoseItemClassLevel: none;
 }
 
-relation.pt_route[!colour][color],
+*.pt_route[!colour][color],
 relation.pt_route_master[!colour][color]
 {
 	throwError: tr("The color of the public transport line should be in a colour tag");
 	fixChangeKey: "color=>colour";
 }
 
-relation.pt_route["fixme:relation"="order members"]
+*.pt_route["fixme:relation"="order members"]
 {
 	throwWarning: tr("The stops may not be in the right order");
 	-osmoseItemClassLevel: none;
 }
 
 /* These values are not valid operator or network */
-relation.pt_route["operator"=~/STIF|Kéolis|Véolia/][inside("FR")],
+*.pt_route["operator"=~/STIF|Kéolis|Véolia/][inside("FR")],
 relation.pt_route_master["operator"=~/STIF|Kéolis|Véolia/][inside("FR")]
 {
 	throwError: tr("Check the operator tag : this operator does not exist, it may be a typo");
 }
 
-relation.pt_route["network"=~/STIF|Kéolis|Véolia/][inside("FR")],
+*.pt_route["network"=~/STIF|Kéolis|Véolia/][inside("FR")],
 relation.pt_route_master["network"=~/STIF|Kéolis|Véolia/][inside("FR")]
 {
 	throwError: tr("Check the network tag : this network does not exist, it may be a typo");
@@ -289,7 +289,7 @@ node[highway=bus_stop][operator][inside("FR")]
 	set route_ok
 }
 
-relation.pt_route!.route_ok
+*.pt_route!.route_ok
 {
 	throwError: tr("The line variant does not belong to any line, add it to the route_master relation");
 }
@@ -321,7 +321,7 @@ way.way_platform_in_route[!name]
 	-osmoseItemClassLevel: none;
 }
 
-relation.pt_route[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
+*.pt_route[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
 relation.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
 {
 	throwError: tr("The interval is invalid (try a number of minutes)");
@@ -337,7 +337,7 @@ relation.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[
 	assertMatch: "relation type=route route=bus interval=00:70:00";
 }
 
-relation.pt_route[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
+*.pt_route[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
 relation.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
 {
 	throwError: tr("The duration is invalid (try a number of minutes)");
@@ -350,13 +350,13 @@ relation.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[
 	assertNoMatch: "relation type=route route=bus duration=25:00";
 }
 
-relation.pt_route["interval:conditional"][!interval],
+*.pt_route["interval:conditional"][!interval],
 relation.pt_route_master["interval:conditional"][!interval]
 {
 	throwError: tr("Missing interval tag to specify the main interval");
 }
 
-relation.pt_route["interval:conditional"][!opening_hours],
+*.pt_route["interval:conditional"][!opening_hours],
 relation.pt_route_master["interval:conditional"][!opening_hours]
 {
 	throwError: tr("Missing opening_hours tag");

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -1,10 +1,11 @@
 meta
 {
 	title: "Jungle Bus - validation ruleset";
-	version: "0.12";
+	version: "0.12.1";
 	description: "Uncompromising validation of transit data";
 	author: "nlehuby";
 	link: "https://junglebus.io/";
+	license: "AGPL-3.0-or-later";
 	baselanguage: "en";
 	watch-modified: true;
 	min-josm-version: 14481;

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -106,7 +106,7 @@ relation[type=route_master]
 }
 
 *.pt_route[!network],
-relation.pt_route_master[!network]
+*.pt_route_master[!network]
 {
 	throwError: tr("Missing network tag on a public_transport relation");
 	-osmoseItemClassLevel: "2140/21402/3";
@@ -115,7 +115,7 @@ relation.pt_route_master[!network]
 }
 
 *.pt_route[!operator],
-relation.pt_route_master[!operator]
+*.pt_route_master[!operator]
 {
 	throwError: tr("Missing operator tag on a public_transport relation");
 	-osmoseItemClassLevel: "2140/21403/3";
@@ -124,7 +124,7 @@ relation.pt_route_master[!operator]
 }
 
 *.pt_route[!ref],
-relation.pt_route_master[!ref]
+*.pt_route_master[!ref]
 {
 	throwWarning: tr("Missing ref tag for line number on a public_transport relation");
     -osmoseItemClassLevel: none;
@@ -169,14 +169,14 @@ relation.pt_route_master[!ref]
 }
 
 *.pt_route[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
-relation.pt_route_master[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+*.pt_route_master[colour][colour=~/^#/][colour!~/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 {
 	throwError: tr("Check the colour tag");
 	-osmoseItemClassLevel: none;
 }
 
 *.pt_route[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/],
-relation.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
+*.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 {
 	throwError: tr("The colour code should start with '#' followed by 3 or 6 digits");
 	fixAdd: concat("colour=#", tag(colour));
@@ -184,7 +184,7 @@ relation.pt_route_master[colour][colour=~/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/]
 }
 
 *.pt_route[!colour][color],
-relation.pt_route_master[!colour][color]
+*.pt_route_master[!colour][color]
 {
 	throwError: tr("The color of the public transport line should be in a colour tag");
 	fixChangeKey: "color=>colour";
@@ -198,13 +198,13 @@ relation.pt_route_master[!colour][color]
 
 /* These values are not valid operator or network */
 *.pt_route["operator"=~/STIF|Kéolis|Véolia/][inside("FR")],
-relation.pt_route_master["operator"=~/STIF|Kéolis|Véolia/][inside("FR")]
+*.pt_route_master["operator"=~/STIF|Kéolis|Véolia/][inside("FR")]
 {
 	throwError: tr("Check the operator tag : this operator does not exist, it may be a typo");
 }
 
 *.pt_route["network"=~/STIF|Kéolis|Véolia/][inside("FR")],
-relation.pt_route_master["network"=~/STIF|Kéolis|Véolia/][inside("FR")]
+*.pt_route_master["network"=~/STIF|Kéolis|Véolia/][inside("FR")]
 {
 	throwError: tr("Check the network tag : this network does not exist, it may be a typo");
 }
@@ -322,7 +322,7 @@ way.way_platform_in_route[!name]
 }
 
 *.pt_route[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
-relation.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+*.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
 {
 	throwError: tr("The interval is invalid (try a number of minutes)");
 	assertMatch: "relation type=route route=bus interval=irregular";
@@ -338,7 +338,7 @@ relation.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[
 }
 
 *.pt_route[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
-relation.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+*.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
 {
 	throwError: tr("The duration is invalid (try a number of minutes)");
 	assertMatch: "relation type=route route=bus duration=20minutes";
@@ -351,13 +351,13 @@ relation.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[
 }
 
 *.pt_route["interval:conditional"][!interval],
-relation.pt_route_master["interval:conditional"][!interval]
+*.pt_route_master["interval:conditional"][!interval]
 {
 	throwError: tr("Missing interval tag to specify the main interval");
 }
 
 *.pt_route["interval:conditional"][!opening_hours],
-relation.pt_route_master["interval:conditional"][!opening_hours]
+*.pt_route_master["interval:conditional"][!opening_hours]
 {
 	throwError: tr("Missing opening_hours tag");
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -312,10 +312,10 @@ node.ptv2_platform[!highway][!railway][bus=yes]
 
 *.route_master > *.route
 {
-	set route_ok
+	set route_in_master
 }
 
-*.pt_route!.route_ok
+*.pt_route!.route_in_master
 {
 	throwError: tr("The line variant does not belong to any line, add it to the route_master relation");
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -339,8 +339,12 @@ way.platform_in_route[!name]
 	-osmoseItemClassLevel: none;
 }
 
-*.pt_route[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
-*.pt_route_master[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+*[interval][interval !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+{
+	set bad_interval
+}
+*.pt_route.bad_interval,
+*.pt_route_master.bad_interval
 {
 	throwError: tr("The interval is invalid (try a number of minutes)");
 	assertMatch: "relation type=route route=bus interval=irregular";
@@ -355,8 +359,12 @@ way.platform_in_route[!name]
 	assertMatch: "relation type=route route=bus interval=00:70:00";
 }
 
-*.pt_route[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/],
-*.pt_route_master[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+*[duration][duration !~ /^([0-9][0-9]?[0-9]?|[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?)$/]
+{
+	set bad_duration
+}
+*.pt_route.bad_duration,
+*.pt_route_master.bad_duration
 {
 	throwError: tr("The duration is invalid (try a number of minutes)");
 	assertMatch: "relation type=route route=bus duration=20minutes";
@@ -368,14 +376,22 @@ way.platform_in_route[!name]
 	assertNoMatch: "relation type=route route=bus duration=25:00";
 }
 
-*.pt_route["interval:conditional"][!interval],
-*.pt_route_master["interval:conditional"][!interval]
+*["interval:conditional"][!interval]
+{
+	set conditional_no_interval
+}
+*.pt_route.conditional_no_interval,
+*.pt_route_master.conditional_no_interval
 {
 	throwError: tr("Missing interval tag to specify the main interval");
 }
 
-*.pt_route["interval:conditional"][!opening_hours],
-*.pt_route_master["interval:conditional"][!opening_hours]
+*["interval:conditional"][!opening_hours]
+{
+	set conditional_no_hours
+}
+*.pt_route.conditional_no_hours,
+*.pt_route_master.conditional_no_hours
 {
 	throwError: tr("Missing opening_hours tag");
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -231,7 +231,12 @@ relation[highway=bus_stop]
 	throwError: tr("A bus stop is supposed to be a node");
 }
 
-node[highway=bus_stop][amenity=bus_station]
+node[highway=bus_stop]
+{
+	set ptv1_busstop
+}
+
+*.ptv1_busstop[amenity=bus_station]
 {
 	throwError: tr("Is it a bus stop or a bus station?");
 	fixRemove: "amenity";
@@ -243,7 +248,7 @@ node[amenity=bus_station]
 	-osmoseItemClassLevel: none;
 }
 
-node[highway=bus_stop][!public_transport]
+*.ptv1_busstop[!public_transport]
 {
 	throwError: tr("Specify if it is a stop (platform) or a location on the road (stop_position)");
 	group: tr("Missing public_transport tag on a public transport stop");
@@ -282,19 +287,19 @@ node[public_transport=platform][!highway][!railway][bus=yes]
 }
 
 /* The note tag is often used to specify the bus routes or other useful metadata that should have their own tag */
-node[highway=bus_stop][note],
-node[highway=bus_stop][note:fr][inside("FR")]
+*.ptv1_busstop[note],
+*.ptv1_busstop[note:fr][inside("FR")]
 {
 	throwWarning: tr("Check if the note can be deleted");
 }
 
-node[highway=bus_stop][network][inside("FR")]
+*.ptv1_busstop[network][inside("FR")]
 {
 	throwWarning: tr("The network should be on the transport lines and not on the stops");
 	fixRemove: "network";
 }
 
-node[highway=bus_stop][operator][inside("FR")]
+*.ptv1_busstop[operator][inside("FR")]
 {
 	throwWarning: tr("The operator should be on the transport lines and not on the stops");
 	fixRemove: "operator";

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -60,7 +60,12 @@ meta[lang=zh_TW]
 	description: "未妥協驗證的運輸資料";
 }
 
-relation[type=route][!route][!disused:route]
+relation[type=route]
+{
+	set route
+}
+
+*.route[!route][!disused:route]
 {
 	throwError: tr("Missing transportation mode, add a tag route = bus/coach/tram/etc");
 }
@@ -77,7 +82,7 @@ relation[type=route_master][!route_master][route]
 	fixChangeKey: "route=>route_master";
 }
 
-relation[type=route][route=~/^(bus|coach|train|subway|monorail|trolleybus|aerialway|funicular|ferry|tram|share_taxi|light_rail|school_bus|walking_bus)$/]
+*.route[route=~/^(bus|coach|train|subway|monorail|trolleybus|aerialway|funicular|ferry|tram|share_taxi|light_rail|school_bus|walking_bus)$/]
 {
 	set pt_route;
 }
@@ -274,7 +279,7 @@ node[highway=bus_stop][operator][inside("FR")]
 	fixRemove: "operator";
 }
 
-relation[type=route_master] > relation[type=route]
+relation[type=route_master] > *.route
 {
 	set route_ok
 }
@@ -284,11 +289,11 @@ relation.pt_route!.route_ok
 	throwError: tr("The line variant does not belong to any line, add it to the route_master relation");
 }
 
-relation[type=route] > node[public_transport=platform]
+*.route > node[public_transport=platform]
 {
 	set platform_in_route
 }
-relation[type=route] > way[public_transport=platform]
+*.route > way[public_transport=platform]
 {
 	set way_platform_in_route
 }

--- a/transport.validator.mapcss
+++ b/transport.validator.mapcss
@@ -409,8 +409,12 @@ relation[public_transport=stop_area]
 {
 	set stop_area
 }
+node[railway=subway_entrance]
+{
+	set subway_entrance
+}
 
-*.stop_area > node[railway=subway_entrance]
+*.stop_area > *.subway_entrance
 {
 	set subway_entrance_in_stop_area
 }
@@ -419,14 +423,14 @@ relation[public_transport=stop_area]
 	set train_station_entrance_in_stop_area
 }
 
-node[railway=subway_entrance]!.subway_entrance_in_stop_area,
+*.subway_entrance!.subway_entrance_in_stop_area,
 node[railway=train_station_entrance]!.train_station_entrance_in_stop_area
 {
 	throwError: tr("The station entrance should be in part of a station: add it to a stop_area relation");
 	-osmoseItemClassLevel: none;
 }
 
-way > node[railway=subway_entrance]
+way > *.subway_entrance
 {
 	set subway_entrance_in_way
 }
@@ -435,7 +439,7 @@ way > node[railway=train_station_entrance]
 	set train_station_entrance_in_way
 }
 
-node[railway=subway_entrance]!.subway_entrance_in_way,
+*.subway_entrance!.subway_entrance_in_way,
 node[railway=train_station_entrance]!.train_station_entrance_in_way
 {
 	throwWarning: tr("The station entrance should be part of a building or a highway (steps, footway, etc)");


### PR DESCRIPTION
Almost all of this falls into two categories:
- Creating classes to deduplicate selectors
- Replacing `node`/`way`/`relation` selectors with `*` in cases where the former were redundant because later class selectors already specified that type.

I'm confident that the actual logic of the ruleset has not changed (that's for future PRs).

It looks like the i18n files might not have generated properly?